### PR TITLE
Fix URL of related user story when from external project

### DIFF
--- a/back/taiga_contrib_slack/templates/taiga_contrib_slack/create.jinja
+++ b/back/taiga_contrib_slack/templates/taiga_contrib_slack/create.jinja
@@ -10,7 +10,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
     {% set final_url = resolve_front_url("epic", obj.project.slug, obj.ref) %}
     {{ _("New Epic created: ") }} *<{{final_url}}|#{{obj.ref}}: {{obj.subject|safe}}>*
 {% elif obj_type == "relateduserstory" %}
-    {% set userstory_url = resolve_front_url("userstory", obj.project.slug, obj.user_story.ref) %}
+    {% set userstory_url = resolve_front_url("userstory", obj.user_story.project.slug, obj.user_story.ref) %}
     {% set epic_url = resolve_front_url("epic", obj.project.slug, obj.epic.ref) %}
     {{ _("New user story related: ") }} *<{{userstory_url}}|#{{obj.user_story.ref}}: {{obj.user_story.subject|safe}}>* in the epic *<{{epic_url}}|#{{obj.epic.ref}}: {{obj.epic.subject|safe}}>*
 {% elif obj_type == "issue" %}

--- a/back/taiga_contrib_slack/templates/taiga_contrib_slack/delete.jinja
+++ b/back/taiga_contrib_slack/templates/taiga_contrib_slack/delete.jinja
@@ -9,7 +9,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
 {% if obj_type == "epic" %}
     {{ _("Deleted Epic: ") }} *#{{obj.ref}}: {{obj.subject}}*
 {% elif obj_type == "relateduserstory" %}
-    {% set userstory_url = resolve_front_url("userstory", obj.project.slug, obj.user_story.ref) %}
+    {% set userstory_url = resolve_front_url("userstory", obj.user_story.project.slug, obj.user_story.ref) %}
     {% set epic_url = resolve_front_url("epic", obj.project.slug, obj.epic.ref) %}
     {{ _("Related user story deleted: ") }} *#{{obj.user_story.ref}}: {{obj.user_story.subject}}* in the epic *<{{epic_url}}|#{{obj.epic.ref}}: {{obj.epic.subject|safe}}>*
 {% elif obj_type == "issue" %}


### PR DESCRIPTION
In case of external projects the link to the usertsory is generated from the project with the linked epic.